### PR TITLE
Add SqlSeeder construct to initialized RDS schema

### DIFF
--- a/cdk/pet_stack/README.md
+++ b/cdk/pet_stack/README.md
@@ -6,9 +6,10 @@ The `cdk.json` file tells the CDK Toolkit how to execute your app.
 
 ## Useful commands
 
- * `npm run build`   compile typescript to js
- * `npm run watch`   watch for changes and compile
- * `npm run test`    perform the jest unit tests
- * `cdk deploy`      deploy this stack to your default AWS account/region
- * `cdk diff`        compare deployed stack with current state
- * `cdk synth`       emits the synthesized CloudFormation template
+ * `npm run build:sql-seeder` build SqlSeeder lambda package
+ * `npm run build`            compile typescript to js
+ * `npm run watch`            watch for changes and compile
+ * `npm run test`             perform the jest unit tests
+ * `cdk deploy`               deploy this stack to your default AWS account/region
+ * `cdk diff`                 compare deployed stack with current state
+ * `cdk synth`                emits the synthesized CloudFormation template

--- a/cdk/pet_stack/lambda/sqlserver-seeder/.gitignore
+++ b/cdk/pet_stack/lambda/sqlserver-seeder/.gitignore
@@ -1,0 +1,1 @@
+Modules

--- a/cdk/pet_stack/lambda/sqlserver-seeder/Bootstrap.cs
+++ b/cdk/pet_stack/lambda/sqlserver-seeder/Bootstrap.cs
@@ -1,0 +1,11 @@
+using Amazon.Lambda.PowerShellHost;
+
+namespace seed
+{
+    public class Bootstrap : PowerShellFunctionHost
+    {
+        public Bootstrap() : base("seed.ps1")
+        {
+        }
+    }
+}

--- a/cdk/pet_stack/lambda/sqlserver-seeder/SQL/v1.0.0.sql
+++ b/cdk/pet_stack/lambda/sqlserver-seeder/SQL/v1.0.0.sql
@@ -1,0 +1,33 @@
+USE [master]
+GO
+
+/****** Object:  Database [adoptions]    Script Date: 4/24/2020 2:02:30 PM ******/
+CREATE DATABASE [adoptions]
+CONTAINMENT = NONE
+ON  PRIMARY 
+( NAME = N'adoptions', FILENAME = N'D:\rdsdbdata\DATA\adoptions.mdf' , SIZE = 8192KB , MAXSIZE = UNLIMITED, FILEGROWTH = 10%)
+LOG ON 
+( NAME = N'adoptions_log', FILENAME = N'D:\rdsdbdata\DATA\adoptions_log.ldf' , SIZE = 1024KB , MAXSIZE = 2048GB , FILEGROWTH = 10%)
+GO
+
+USE [adoptions]
+GO
+
+/****** Object:  Table [dbo].[Transactions]    Script Date: 4/23/2020 10:07:28 PM ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE TABLE [dbo].[Transactions](
+	[Id] [int] IDENTITY(1,1) NOT NULL,
+	[PetId] [nvarchar](50) NULL,
+	[Adoption_Date] [datetime] NULL,
+	[Transaction_Id] [nvarchar](50) NULL,
+PRIMARY KEY CLUSTERED 
+(
+	[Id] ASC
+) WITH (PAD_INDEX = OFF, STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF, ALLOW_ROW_LOCKS = ON, ALLOW_PAGE_LOCKS = ON) ON [PRIMARY]
+) ON [PRIMARY]
+GO

--- a/cdk/pet_stack/lambda/sqlserver-seeder/aws-lambda-tools-defaults.json
+++ b/cdk/pet_stack/lambda/sqlserver-seeder/aws-lambda-tools-defaults.json
@@ -1,0 +1,15 @@
+{
+    "profile"     : "",
+    "region"      : "",
+    "configuration" : "Release",
+    "framework"     : "netcoreapp3.1",
+    "function-runtime" : "dotnetcore3.1",
+    "function-memory-size" : 512,
+    "function-timeout"     : 90,
+    "function-handler"     : "seed::seed.Bootstrap::ExecuteFunction",
+    "function-name"        : "",
+    "function-role"        : "",
+    "tracing-mode"         : "",
+    "environment-variables" : "",
+    "apply-defaults"        : true
+}

--- a/cdk/pet_stack/lambda/sqlserver-seeder/seed.csproj
+++ b/cdk/pet_stack/lambda/sqlserver-seeder/seed.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Content Include="seed.ps1">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="./SQL/**">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+        <Content Include="./Modules/**">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.0.0" />
+        <PackageReference Include="Amazon.Lambda.Core" Version="1.1.0" />
+        <PackageReference Include="Amazon.Lambda.PowerShellHost" Version="2.0.0" />
+    </ItemGroup>
+</Project>

--- a/cdk/pet_stack/lambda/sqlserver-seeder/seed.ps1
+++ b/cdk/pet_stack/lambda/sqlserver-seeder/seed.ps1
@@ -1,0 +1,69 @@
+#Requires -Modules @{ModuleName='AWS.Tools.Common';ModuleVersion='4.0.5.0'}
+#Requires -Modules @{ModuleName='AWS.Tools.SimpleSystemsManagement';ModuleVersion='4.0.5.0'}
+#Requires -Modules @{ModuleName='SqlServer';ModuleVersion='21.1.18221'}
+
+function SeedInitialSchema {
+	$dbEndpoint = $env:DbEndpoint
+	$usernameParameter = $env:UsernameParameter
+	$passwordParameter = $env:PasswordParameter
+
+	$username = (Get-SSMParameter -Name $usernameParameter).Value
+	$password = (Get-SSMParameter -Name $passwordParameter).Value
+	$connectionString = "Server=${dbEndpoint};User Id=${username};Password=${password}"
+	$script = "./SQL/v1.0.0.sql"
+
+	Invoke-Sqlcmd -ConnectionString $connectionString -InputFile $script
+}
+
+# The following is a standard template for custom resource implementation.
+# Note that only Create event is handled. 
+
+$CFNEvent = if ($null -ne $LambdaInput.Records) {
+	Write-Host 'Message received via SNS - Parsing out CloudFormation event'
+	$LambdaInput.Records[0].Sns.Message
+}
+else {
+	Write-Host 'Event received directly from CloudFormation'
+	$LambdaInput
+}
+$body = @{
+	# We'll assume success and overwrite if anything fails in line to avoid code duplication
+	Status             = "SUCCESS"
+	Reason             = "See the details in CloudWatch Log Stream:`n[Group] $($LambdaContext.LogGroupName)`n[Stream] $($LambdaContext.LogStreamName)"
+	PhysicalResourceId = $LambdaContext.LogStreamName
+	StackId            = $CFNEvent.StackId
+	RequestId          = $CFNEvent.RequestId
+	LogicalResourceId  = $CFNEvent.LogicalResourceId
+}
+Write-Host "Processing RequestType [$($CFNEvent.RequestType)]"
+try {
+	# If you want to return data back to CloudFormation, add the Data property to the body with the value as a hashtable. The hashtable keys will be the retrievable attributes when using Fn::GetAtt against the custom resource in your CloudFormation template:
+	#    $body.Data = @{Secret = $null}
+	switch ($CFNEvent.RequestType) {
+			Create {
+					# Add Create request code here
+					SeedInitialSchema
+			}
+			Update {
+					# Add Update request code here
+					Write-Host 'SQL Seeder does not support schema updates. Return success.'
+			}
+			Delete {
+					# Add Delete request code here
+					Write-Host 'SQL Seeder does not support deletion of the schema. Return success.'
+			}
+	}
+}
+catch {
+	Write-Error $_
+	$body.Status = "FAILED"
+}
+finally {
+	try {
+			Write-Host "Sending response back to CloudFormation"
+			Invoke-WebRequest -Uri $([Uri]$CFNEvent.ResponseURL) -Method Put -Body $($body | ConvertTo-Json -Depth 5)
+	}
+	catch {
+			Write-Error $_
+	}
+}

--- a/cdk/pet_stack/lib/services.ts
+++ b/cdk/pet_stack/lib/services.ts
@@ -14,6 +14,7 @@ import * as ddbseeder from 'aws-cdk-dynamodb-seeder'
 import * as s3seeder from '@aws-cdk/aws-s3-deployment'
 import * as rds from '@aws-cdk/aws-rds';
 
+import { SqlSeeder } from './sql-seeder'
 // https://stackoverflow.com/questions/59710635/how-to-connect-aws-ecs-applicationloadbalancedfargateservice-private-ip-to-rds
 
 export class Services extends cdk.Stack {
@@ -113,6 +114,13 @@ export class Services extends cdk.Stack {
                 "xray:PutTelemetryRecords"
             ]
         });
+        var sqlSeeder = new SqlSeeder(this, "sql-seeder", {
+            vpc: theVPC,
+            database: instance,
+            port: 1433,
+            username: rdsUsername,
+            password: rdsPassword
+        })
 
         const readSSMParamsPolicy = new iam.PolicyStatement({
             effect: iam.Effect.ALLOW,

--- a/cdk/pet_stack/lib/sql-seeder.ts
+++ b/cdk/pet_stack/lib/sql-seeder.ts
@@ -1,0 +1,63 @@
+import * as cdk from '@aws-cdk/core';
+import * as ec2 from '@aws-cdk/aws-ec2';
+import * as lambda from '@aws-cdk/aws-lambda';
+import * as rds from '@aws-cdk/aws-rds';
+import * as cr from '@aws-cdk/custom-resources';
+import * as ssm from '@aws-cdk/aws-ssm';
+
+export interface SqlSeederProps {
+  vpc: ec2.Vpc;
+  database: rds.DatabaseInstance,
+  port: number,
+  username: string,
+  password: string
+}
+
+export class SqlSeeder extends cdk.Construct {
+
+  constructor(scope: cdk.Construct, id: string, props: SqlSeederProps) {
+    super(scope, id);
+
+    const dbIdentifier = props.database.instanceIdentifier;
+    const rdsUsernameParameter = new ssm.StringParameter(this, 'RDSUsernameParameter', {
+      parameterName: `/sql-seeder/${dbIdentifier}/username`,
+      stringValue: props.username,
+      simpleName: false
+    });
+
+    const rsdPasswordParameter = new ssm.StringParameter(this, 'RDSPasswordParameter', {
+        parameterName: `/sql-seeder/${dbIdentifier}/password`,
+        stringValue: props.password,
+        simpleName: false
+    });
+
+    const sqlSeederLambda = new lambda.Function(this, 'sql-seeder-lambda', {      
+        code: new lambda.AssetCode('./lambda/sqlserver-seeder.zip'),
+        handler: 'seed::seed.Bootstrap::ExecuteFunction',
+        timeout: cdk.Duration.seconds(300),
+        runtime: lambda.Runtime.DOTNET_CORE_3_1,
+        memorySize: 512,
+        vpc: props.vpc,
+        vpcSubnets: {
+            subnetType: ec2.SubnetType.PRIVATE
+        },
+        environment: {
+            "DbEndpoint": props.database.dbInstanceEndpointAddress,
+            "UsernameParameter": rdsUsernameParameter.parameterName,
+            "PasswordParameter": rsdPasswordParameter.parameterName
+        }
+    });
+
+    const sqlSeederProvider = new cr.Provider(this, 'sqlserver-seeder-provider', {
+      onEventHandler: sqlSeederLambda
+    });
+    const sqlSeederResource = new cdk.CustomResource(this, 'SqlSeeder', { serviceToken: sqlSeederProvider.serviceToken });
+    sqlSeederResource.node.addDependency(props.database);
+
+    // enable connection to RDS instance
+    sqlSeederLambda.connections.allowTo(props.database, ec2.Port.tcp(props.port));
+    // grant access to SSM parameters
+    rdsUsernameParameter.grantRead(sqlSeederLambda);
+    rsdPasswordParameter.grantRead(sqlSeederLambda);
+  }
+}

--- a/cdk/pet_stack/package.json
+++ b/cdk/pet_stack/package.json
@@ -5,6 +5,7 @@
     "pet_stack": "bin/pet_stack.js"
   },
   "scripts": {
+    "build:sql-seeder": "pwsh -NoProfile -ExecutionPolicy Unrestricted -command New-AWSPowerShellLambdaPackage -ProjectDirectory './lambda/sqlserver-seeder' -OutputPackage ./lambda/sqlserver-seeder.zip",
     "build": "tsc",
     "watch": "tsc -w",
     "test": "jest",


### PR DESCRIPTION
Fixes #3 

This is a simple custom resource that deploys SQL script to SQL Server instance once it is initialized.
Tested by re-creating the stack from ground up. 